### PR TITLE
Use Capybara::register_server

### DIFF
--- a/capybara_discoball.gemspec
+++ b/capybara_discoball.gemspec
@@ -26,7 +26,7 @@ present the Discoball.
   s.add_dependency 'capybara', '~> 2.7'
 
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'turnip'
+  s.add_development_dependency 'turnip', '~> 2.1'
   s.add_development_dependency 'aruba'
   s.add_development_dependency 'sinatra'
 

--- a/capybara_discoball.gemspec
+++ b/capybara_discoball.gemspec
@@ -23,7 +23,7 @@ present the Discoball.
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'capybara'
+  s.add_dependency 'capybara', '~> 2.7'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'turnip'

--- a/lib/capybara_discoball/runner.rb
+++ b/lib/capybara_discoball/runner.rb
@@ -22,13 +22,13 @@ module Capybara
 
       def with_webrick_runner
         default_server_process = Capybara.server
-        Capybara.server do |app, port|
+        Capybara.register_server :webrick do |app, port|
           require "rack/handler/webrick"
           Rack::Handler::WEBrick.run(app, Port: port, AccessLog: [], Logger: WEBrick::Log::new(nil, 0))
         end
         yield
       ensure
-        Capybara.server(&default_server_process)
+        Capybara.register_server(:default, &default_server_process)
       end
     end
   end


### PR DESCRIPTION
To suppress `DEPRECATED: Passing a block to Capybara::server is deprecated, please use Capybara::register_server instead` messages.

I didn't really see any necessity for extra test code. I've also added capistrano version dependency, as it is likely to break in the future.

references: [2.7.0 release](https://github.com/jnicklas/capybara/blob/master/History.md#version-270) and https://github.com/jnicklas/capybara/pull/1654